### PR TITLE
freshdesk-import: init

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -17,4 +17,11 @@ in
 
     meta.platforms = lib.platforms.linux;
   };
+
+  holo-auth-freshdesk-import = with python37Packages; buildPythonApplication {
+    name = "holo-auth-freshdesk-import";
+    src = gitignoreSource ./freshdesk-import;
+
+    propagatedBuildInputs = [ requests ];
+  };
 }

--- a/freshdesk-import/holo_auth_freshdesk_import/main.py
+++ b/freshdesk-import/holo_auth_freshdesk_import/main.py
@@ -1,0 +1,50 @@
+import os
+import requests
+import time
+
+CLOUDFLARE_ACCOUNT_ID = '18ff2b4e6205b938652998cfca0d8cff'
+CLOUDFLARE_WHITELIST_ID = '3130e2ca2d234214ba9db91622f7f197'
+FRESHDESK_COMPANY_ID = 36000445120
+
+
+def freshdesk_api_key():
+    return os.environ['FRESHDESK_API_KEY']
+
+
+def freshdesk_contacts(page):
+    return requests.get(
+        'https://holo.freshdesk.com/api/v2/contacts',
+        auth=(freshdesk_api_key(), '_'),
+        params={'company_id': FRESHDESK_COMPANY_ID, 'page': page}).json()
+
+
+def freshdesk_all_contacts():
+    all_contacts = []
+    current_page = 1
+    while True:
+        contacts = freshdesk_contacts(current_page)
+        if contacts == []:
+            return all_contacts
+        all_contacts += contacts
+        current_page += 1
+        # https://developers.freshdesk.com/api/#ratelimit
+        time.sleep(1)
+
+
+def cloudflare_api_token():
+    return os.environ['CLOUDFLARE_API_TOKEN']
+
+
+def cloudflare_whitelist_import(emails):
+    requests.put('https://api.cloudflare.com/client/v4/accounts/{}/storage/kv/namespaces/{}/bulk'.format(CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_WHITELIST_ID),
+        headers={'authorization': 'Bearer ' + cloudflare_api_token()},
+        json=list(map(lambda email: {'key': email, 'value': '{}', 'base64': False}, emails)))
+
+
+def main():
+    emails = list(map(lambda contact: contact['email'], freshdesk_all_contacts()))
+    cloudflare_whitelist_import(emails)
+
+
+if __name__ == '__main__':
+    main()

--- a/freshdesk-import/setup.py
+++ b/freshdesk-import/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup
+
+setup(
+    name='holo-auth-freshdesk-import',
+    packages=['holo_auth_freshdesk_import'],
+    entry_points={
+        'console_scripts': [
+            'holo-auth-freshdesk-import=holo_auth_freshdesk_import.main:main'
+        ],
+    },
+    install_requires=['requests']
+)


### PR DESCRIPTION
This PR introduces a Python tool that imports Freshdesk email data into whitelist Cloudflare KV store.

I already ran the tool and KV store is already populated. Meaning, Holo Auth now works for external (non `@holo.host`) email addresses.

cc @alastairong 