### PR TITLE
server: set ZeroTier device name and description to agent ID and email

### DIFF
--- a/server/src/routes/challenge.js
+++ b/server/src/routes/challenge.js
@@ -49,7 +49,8 @@ const responseUrl = async (baseUrl, payload) => {
 
 const handle = async req => {
   const baseUrl = await SETTINGS.get('response_base_url') || new URL('/v1/response', req.parsedURL.origin)
-  const { email, ...payload } = await req.json()
+  const payload = await req.json()
+  const { email } = payload
 
   if (!await isWhitelisted(email)) {
     return sendEmail(email, 'not-whitelisted', {})

--- a/server/src/routes/response.js
+++ b/server/src/routes/response.js
@@ -3,7 +3,7 @@
 import * as hmac from '../hmac'
 import { respond } from '../util'
 
-const addZeroTierMember = async address => {
+const addZeroTierMember = async (address, name, description) => {
   const apiToken = await SETTINGS.get('zerotier_central_api_token')
   const networkId = await SETTINGS.get('zerotier_network_id')
 
@@ -11,7 +11,9 @@ const addZeroTierMember = async address => {
     method: 'POST',
     headers: { authorization: `Bearer ${apiToken}` },
     body: JSON.stringify({
-      config: { authorized: true }
+      config: { authorized: true },
+      description: description,
+      name: name
     })
   })
 }
@@ -20,10 +22,10 @@ const handle = async req => {
   const { data, signature } = Object.fromEntries(req.parsedURL.searchParams)
   if (!await hmac.verify(Buffer.from(signature, 'base64'), Buffer.from(data))) { return respond(401) }
 
-  const payload = JSON.parse(data)
-  if (payload.valid_until < Date.now()) { return respond(401) }
+  const { email, holochain_agent_id, valid_until, zerotier_address } = JSON.parse(data)
+  if (valid_until < Date.now()) { return respond(401) }
 
-  return addZeroTierMember(payload.zerotier_address)
+  return addZeroTierMember(zerotier_address, holochain_agent_id, email)
 }
 
 export { handle }


### PR DESCRIPTION
Resolves #11 for new registrations. So, ZeroTier Central supports accounts with limited permissions, and support will have read-only access. They will be able to find registrations quickly by agent ID, email, or ZeroTier address, and check networking metadata, all in one place. Importing relevant data from Freshdesk is tracked separately in #18.