### PR TITLE
fix: added content type and updated accept header

### DIFF
--- a/server/src/routes/notify.js
+++ b/server/src/routes/notify.js
@@ -39,7 +39,8 @@ const sendEmail = async (val) => {
   return fetch('https://api.postmarkapp.com/email/withTemplate', {
     method: 'POST',
     headers: {
-      accept: 'application/json',
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
       'x-postmark-server-token': serverToken
     },
     body: JSON.stringify(payload)


### PR DESCRIPTION
Missing Content-Type can cause the request to fail from postmark