### PR TITLE
[B-06293] zt_registration checks if registrant is authorized

### DIFF
--- a/server/wrangler.toml
+++ b/server/wrangler.toml
@@ -13,7 +13,7 @@ command = "npm install && npm run build"
 name = "auth-server"
 route = "auth-server.holo.host/*"
 kv_namespaces = [
-    { binding = "SETTINGS", id = "5181f479e6d84fc9835c5195b08a7029"}
+    { binding = "SETTINGS", id = "56ecfe1cf54d43839e2c867798e5003b"}
 ]
 
 main = "dist/main.js"


### PR DESCRIPTION
`zt_registration` endpoint reads the content of registration request and checks in `opsconsoledb.registrations` db if user is in fact registered and authorized to access ZT network.

This PR:
- adds check in db if user is authorized to register
- splits KV auth-server-settings between one for devnet and one for alpha

NOTE:
- before this code is merged to main we need to open API access to Production db and update `mongodb_api_key` in `auth-server-settings` KV store.