### PR TITLE
update urls to 3rd level subdomains

### DIFF
--- a/server/wrangler.toml
+++ b/server/wrangler.toml
@@ -1,6 +1,6 @@
 name = "devnet-auth-server"
 account_id = "18ff2b4e6205b938652998cfca0d8cff"
-route = "auth-server.dev.holotest.net/*"
+route = "dev-auth-server.holotest.net/*"
 compatibility_date = "2024-02-19"
 main = "dist/main.js"
 kv_namespaces = [
@@ -19,7 +19,7 @@ kv_namespaces = [
 
 [env.qanet]
 name = "qa-auth-server"
-route = "auth-server.qa.holotest.net/*"
+route = "qa-auth-server.holotest.net/*"
 kv_namespaces = [
     { binding = "SETTINGS", id = "1cfdf3a9b75545408f9058d846648349"}
 ]


### PR DESCRIPTION
Like in the title, otherwise our universal TLS cert for holotest.net is not working